### PR TITLE
Use diego logging client in place of compatibility

### DIFF
--- a/cmd/locket/config/config.go
+++ b/cmd/locket/config/config.go
@@ -5,22 +5,22 @@ import (
 	"os"
 
 	"code.cloudfoundry.org/debugserver"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/lager/lagerflags"
 )
 
 type LocketConfig struct {
-	CaFile                     string                `json:"ca_file"`
-	CertFile                   string                `json:"cert_file"`
-	ConsulCluster              string                `json:"consul_cluster,omitempty"`
-	DatabaseConnectionString   string                `json:"database_connection_string"`
-	MaxOpenDatabaseConnections int                   `json:"max_open_database_connections,omitempty"`
-	DatabaseDriver             string                `json:"database_driver,omitempty"`
-	DropsondePort              int                   `json:"dropsonde_port,omitempty"`
-	KeyFile                    string                `json:"key_file"`
-	ListenAddress              string                `json:"listen_address"`
-	SQLCACertFile              string                `json:"sql_ca_cert_file,omitempty"`
-	LoggregatorConfig          loggregator_v2.Config `json:"loggregator"`
+	CaFile                     string               `json:"ca_file"`
+	CertFile                   string               `json:"cert_file"`
+	ConsulCluster              string               `json:"consul_cluster,omitempty"`
+	DatabaseConnectionString   string               `json:"database_connection_string"`
+	MaxOpenDatabaseConnections int                  `json:"max_open_database_connections,omitempty"`
+	DatabaseDriver             string               `json:"database_driver,omitempty"`
+	DropsondePort              int                  `json:"dropsonde_port,omitempty"`
+	KeyFile                    string               `json:"key_file"`
+	ListenAddress              string               `json:"listen_address"`
+	SQLCACertFile              string               `json:"sql_ca_cert_file,omitempty"`
+	LoggregatorConfig          loggingclient.Config `json:"loggregator"`
 	debugserver.DebugServerConfig
 	lagerflags.LagerConfig
 }

--- a/cmd/locket/config/config_test.go
+++ b/cmd/locket/config/config_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"code.cloudfoundry.org/debugserver"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/lager/lagerflags"
 	"code.cloudfoundry.org/locket/cmd/locket/config"
 
@@ -81,7 +81,7 @@ var _ = Describe("LocketConfig", func() {
 			CertFile:      "i am a cert file",
 			KeyFile:       "i am a key file",
 			SQLCACertFile: "/var/vcap/jobs/locket/config/sql.ca",
-			LoggregatorConfig: loggregator_v2.Config{
+			LoggregatorConfig: loggingclient.Config{
 				UseV2API:      true,
 				APIPort:       1234,
 				CACertPath:    "/var/ca_cert",

--- a/cmd/locket/locket_test.go
+++ b/cmd/locket/locket_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
-	"code.cloudfoundry.org/go-loggregator/testhelpers"
 	"code.cloudfoundry.org/lager/lagertest"
 	"code.cloudfoundry.org/localip"
 	"code.cloudfoundry.org/locket"

--- a/cmd/locket/main.go
+++ b/cmd/locket/main.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"time"
 
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/go-loggregator/runtimeemitter"
 	"github.com/cloudfoundry/dropsonde"
 	"github.com/go-sql-driver/mysql"
@@ -165,8 +165,8 @@ func initializeDropsonde(logger lager.Logger, dropsondePort int) {
 	}
 }
 
-func initializeMetron(logger lager.Logger, locketConfig config.LocketConfig) (loggregator_v2.IngressClient, error) {
-	client, err := loggregator_v2.NewIngressClient(locketConfig.LoggregatorConfig)
+func initializeMetron(logger lager.Logger, locketConfig config.LocketConfig) (loggingclient.IngressClient, error) {
+	client, err := loggingclient.NewIngressClient(locketConfig.LoggregatorConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/clock"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/locket/db"
 	"code.cloudfoundry.org/locket/models"
@@ -22,10 +22,10 @@ type metricsNotifier struct {
 	ticker          clock.Clock
 	metricsInterval time.Duration
 	lockDB          db.LockDB
-	metronClient    loggregator_v2.IngressClient
+	metronClient    loggingclient.IngressClient
 }
 
-func NewMetricsNotifier(logger lager.Logger, ticker clock.Clock, metronClient loggregator_v2.IngressClient, metricsInterval time.Duration, lockDB db.LockDB) ifrit.Runner {
+func NewMetricsNotifier(logger lager.Logger, ticker clock.Clock, metronClient loggingclient.IngressClient, metricsInterval time.Duration, lockDB db.LockDB) ifrit.Runner {
 	return &metricsNotifier{
 		logger:          logger,
 		ticker:          ticker,

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/clock/fakeclock"
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	"code.cloudfoundry.org/locket/db/dbfakes"


### PR DESCRIPTION
This work upgrades Diego to use go-loggregator v3.0.0. It also encapsulates Diego's use of the loggregator client behind a single interface found in `diego-logging-client` within `diego-release`.

By wrapping go-loggregator in Diego, we ensure future upgrades to go-loggregator will not require such large change sets.

This PR goes hand in hand with the following PRs:
- [diego-release](https://github.com/cloudfoundry/diego-release/pull/349)
- [auctioneer](https://github.com/cloudfoundry/auctioneer/pull/6)
- [bbs](https://github.com/cloudfoundry/bbs/pull/24)
- [benchmarkbbs](https://github.com/cloudfoundry/benchmarkbbs/pull/3)
- [rep](https://github.com/cloudfoundry/rep/pull/17)
- [executor](https://github.com/cloudfoundry/executor/pull/27)
- [volman](https://github.com/cloudfoundry/volman/pull/4)

[#148451433]

Signed-off-by: Jason Keene <jkeene@pivotal.io>