### PR TITLE
Use jackc/pgx instead of lib/pq

### DIFF
--- a/cmd/locket/main.go
+++ b/cmd/locket/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"flag"
 	"net"
 	"os"
@@ -57,7 +56,7 @@ func main() {
 
 	clock := clock.NewClock()
 
-	connectionString := helpers.AddTLSParams(
+	sqlConn, err := helpers.Connect(
 		logger,
 		cfg.DatabaseDriver,
 		cfg.DatabaseConnectionString,
@@ -65,7 +64,6 @@ func main() {
 		cfg.SQLEnableIdentityVerification,
 	)
 
-	sqlConn, err := sql.Open(cfg.DatabaseDriver, connectionString)
 	if err != nil {
 		logger.Fatal("failed-to-open-sql", err)
 	}

--- a/db/sqldb_suite_test.go
+++ b/db/sqldb_suite_test.go
@@ -14,8 +14,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	_ "github.com/lib/pq"
-
 	"testing"
 )
 
@@ -55,7 +53,8 @@ var _ = BeforeSuite(func() {
 
 	// mysql must be set up on localhost as described in the CONTRIBUTING.md doc
 	// in diego-release.
-	rawDB, err = sql.Open(dbDriverName, dbBaseConnectionString)
+	rawDB, err = helpers.Connect(logger, dbDriverName, dbBaseConnectionString, "", false)
+
 	Expect(err).NotTo(HaveOccurred())
 	Expect(rawDB.Ping()).NotTo(HaveOccurred())
 
@@ -63,7 +62,8 @@ var _ = BeforeSuite(func() {
 	_, err = rawDB.Exec(fmt.Sprintf("CREATE DATABASE diego_%d", GinkgoParallelNode()))
 	Expect(err).NotTo(HaveOccurred())
 
-	rawDB, err = sql.Open(dbDriverName, fmt.Sprintf("%sdiego_%d", dbBaseConnectionString, GinkgoParallelNode()))
+	connStringWithDB := fmt.Sprintf("%sdiego_%d", dbBaseConnectionString, GinkgoParallelNode())
+	rawDB, err = helpers.Connect(logger, dbDriverName, connStringWithDB, "", false)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(rawDB.Ping()).NotTo(HaveOccurred())
 
@@ -93,7 +93,7 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	Expect(rawDB.Close()).NotTo(HaveOccurred())
-	rawDB, err := sql.Open(dbDriverName, dbBaseConnectionString)
+	rawDB, err := helpers.Connect(logger, dbDriverName, dbBaseConnectionString, "", false)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(rawDB.Ping()).NotTo(HaveOccurred())
 	_, err = rawDB.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS diego_%d", GinkgoParallelNode()))

--- a/handlers/context_test.go
+++ b/handlers/context_test.go
@@ -46,7 +46,7 @@ var _ = Describe("LocketHandler", func() {
 		sqlProcess = ginkgomon.Invoke(sqlRunner)
 
 		var err error
-		sqlConn, err = sql.Open(sqlRunner.DriverName(), sqlRunner.ConnectionString())
+		sqlConn, err = helpers.Connect(logger, sqlRunner.DriverName(), sqlRunner.ConnectionString(), "", false)
 		Expect(err).NotTo(HaveOccurred())
 
 		dbMonitor := monitor.New()


### PR DESCRIPTION
The pq library is in maintainance mode according ot the repository's
[README](https://github.com/lib/pq/tree/f3b22b2cad9e4567803b7ffd9853b8acda021438).

> This package is effectively in maintenance mode and is not actively
> developed. Small patches and features are only rarely reviewed and merged. We
> recommend using pgx which is actively maintained.