### PR TITLE
[Locket client]Add gRPC client timeout

### DIFF
--- a/locket_client.go
+++ b/locket_client.go
@@ -60,6 +60,7 @@ func newClientInternal(logger lager.Logger, config ClientLocketConfig, skipCertV
 		grpc.WithTimeout(10*time.Second), // ensure that grpc won't keep retrying forever
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time: 10 * time.Second,
+			Timeout: 10 * time.Second, 
 		}),
 	)
 	if err != nil {


### PR DESCRIPTION
This PR is a follow up to this issue: https://github.com/cloudfoundry/diego-release/issues/627. The timeout is hardcoded, since if we wanted to make it configurable, we would need to modify all the component that use the client. I would say that for now, 10s should be perfectly fine for all use cases. 