### PR TITLE
Stop processing the deprecated `Resource.Type` attribute

### DIFF
--- a/cmd/locket/main_test.go
+++ b/cmd/locket/main_test.go
@@ -172,7 +172,7 @@ var _ = Describe("Locket", func() {
 
 				Context("when a lock is acquired", func() {
 					JustBeforeEach(func() {
-						requestedResource := &models.Resource{Key: "test", Value: "test-data", Owner: "jim", Type: "lock"}
+						requestedResource := &models.Resource{Key: "test", Value: "test-data", Owner: "jim", TypeCode: models.LOCK}
 						_, err := locketClient.Lock(context.Background(), &models.LockRequest{
 							Resource:     requestedResource,
 							TtlInSeconds: 10,
@@ -218,7 +218,7 @@ var _ = Describe("Locket", func() {
 						wg.Add(10)
 						for i := 0; i < 10; i++ {
 							key := fmt.Sprintf("test%d", i)
-							requestedResource := &models.Resource{Key: key, Value: "test-data", Owner: key, Type: "lock"}
+							requestedResource := &models.Resource{Key: key, Value: "test-data", Owner: key, TypeCode: models.LOCK}
 							go func() {
 								defer GinkgoRecover()
 								defer wg.Done()
@@ -332,7 +332,7 @@ var _ = Describe("Locket", func() {
 				JustBeforeEach(func() {
 					_, err := sqlRunner.DB().Exec("DROP TABLE locks")
 					Expect(err).NotTo(HaveOccurred())
-					requestedResource := &models.Resource{Key: "test", Value: "test-data", Owner: "jim", Type: "lock"}
+					requestedResource := &models.Resource{Key: "test", Value: "test-data", Owner: "jim", TypeCode: models.LOCK}
 					_, err = locketClient.Lock(context.Background(), &models.LockRequest{
 						Resource:     requestedResource,
 						TtlInSeconds: 10,
@@ -347,7 +347,7 @@ var _ = Describe("Locket", func() {
 			})
 
 			It("locks the key with the corresponding value", func() {
-				requestedResource := &models.Resource{Key: "test", Value: "test-data", Owner: "jim", Type: "lock"}
+				requestedResource := &models.Resource{Key: "test", Value: "test-data", Owner: "jim", TypeCode: models.LOCK}
 				expectedResource := &models.Resource{Key: "test", Value: "test-data", Owner: "jim", Type: "lock", TypeCode: models.LOCK}
 				_, err := locketClient.Lock(context.Background(), &models.LockRequest{
 					Resource:     requestedResource,
@@ -359,7 +359,7 @@ var _ = Describe("Locket", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.Resource).To(BeEquivalentTo(expectedResource))
 
-				requestedResource = &models.Resource{Key: "test", Value: "test-data", Owner: "nima", Type: "lock"}
+				requestedResource = &models.Resource{Key: "test", Value: "test-data", Owner: "nima", TypeCode: models.LOCK}
 				_, err = locketClient.Lock(context.Background(), &models.LockRequest{
 					Resource:     requestedResource,
 					TtlInSeconds: 10,
@@ -368,7 +368,7 @@ var _ = Describe("Locket", func() {
 			})
 
 			It("logs the uuid of the request", func() {
-				requestedResource := &models.Resource{Key: "test", Value: "test-data", Owner: "jim", Type: "lock"}
+				requestedResource := &models.Resource{Key: "test", Value: "test-data", Owner: "jim", TypeCode: models.LOCK}
 				ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs("uuid", "some-uuid"))
 				_, err := locketClient.Lock(ctx, &models.LockRequest{
 					Resource:     requestedResource,
@@ -380,7 +380,7 @@ var _ = Describe("Locket", func() {
 			})
 
 			It("expires after a ttl", func() {
-				requestedResource := &models.Resource{Key: "test", Value: "test-data", Owner: "jim", Type: "lock"}
+				requestedResource := &models.Resource{Key: "test", Value: "test-data", Owner: "jim", TypeCode: models.LOCK}
 				_, err := locketClient.Lock(context.Background(), &models.LockRequest{
 					Resource:     requestedResource,
 					TtlInSeconds: 6,
@@ -395,7 +395,7 @@ var _ = Describe("Locket", func() {
 
 			Context("when the lock server disappears unexpectedly", func() {
 				It("still disappears after ~ the ttl", func() {
-					requestedResource := &models.Resource{Key: "test", Value: "test-data", Owner: "jim", Type: "lock"}
+					requestedResource := &models.Resource{Key: "test", Value: "test-data", Owner: "jim", TypeCode: models.LOCK}
 					_, err := locketClient.Lock(context.Background(), &models.LockRequest{
 						Resource:     requestedResource,
 						TtlInSeconds: 3,
@@ -421,7 +421,7 @@ var _ = Describe("Locket", func() {
 
 			Context("when the lock does not exist", func() {
 				It("does not throw an error releasing the lock", func() {
-					requestedResource = &models.Resource{Key: "test", Value: "test-data", Owner: "jim", Type: "lock"}
+					requestedResource = &models.Resource{Key: "test", Value: "test-data", Owner: "jim", TypeCode: models.LOCK}
 					_, err := locketClient.Release(context.Background(), &models.ReleaseRequest{Resource: requestedResource})
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -429,13 +429,14 @@ var _ = Describe("Locket", func() {
 
 			Context("when the lock exists", func() {
 				JustBeforeEach(func() {
-					requestedResource = &models.Resource{Key: "test", Value: "test-data", Owner: "jim", Type: "lock", TypeCode: models.LOCK}
+					requestedResource = &models.Resource{Key: "test", Value: "test-data", Owner: "jim", TypeCode: models.LOCK}
+					expectedResource := &models.Resource{Key: "test", Value: "test-data", Owner: "jim", Type: "lock", TypeCode: models.LOCK}
 					_, err := locketClient.Lock(context.Background(), &models.LockRequest{Resource: requestedResource, TtlInSeconds: 10})
 					Expect(err).NotTo(HaveOccurred())
 
 					resp, err := locketClient.Fetch(context.Background(), &models.FetchRequest{Key: "test"})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(resp.Resource).To(BeEquivalentTo(requestedResource))
+					Expect(resp.Resource).To(BeEquivalentTo(expectedResource))
 				})
 
 				It("releases the lock", func() {
@@ -448,7 +449,7 @@ var _ = Describe("Locket", func() {
 
 				Context("when another process is the lock owner", func() {
 					It("throws an error", func() {
-						requestedResource = &models.Resource{Key: "test", Value: "test-data", Owner: "nima", Type: "lock"}
+						requestedResource = &models.Resource{Key: "test", Value: "test-data", Owner: "nima", TypeCode: models.LOCK}
 						_, err := locketClient.Release(context.Background(), &models.ReleaseRequest{Resource: requestedResource})
 						Expect(err).To(HaveOccurred())
 					})
@@ -485,32 +486,6 @@ var _ = Describe("Locket", func() {
 					TtlInSeconds: 10,
 				})
 				Expect(err).NotTo(HaveOccurred())
-			})
-
-			Context("when using type strings", func() {
-				BeforeEach(func() {
-					resource1 = &models.Resource{Key: "test-lock1", Value: "test-data", Owner: "jim", Type: "lock", TypeCode: models.LOCK}
-					resource2 = &models.Resource{Key: "test-lock2", Value: "test-data", Owner: "jim", Type: "lock", TypeCode: models.LOCK}
-					resource3 = &models.Resource{Key: "test-presence1", Value: "test-data", Owner: "jim", Type: "presence", TypeCode: models.PRESENCE}
-					resource4 = &models.Resource{Key: "test-presence2", Value: "test-data", Owner: "jim", Type: "presence", TypeCode: models.PRESENCE}
-				})
-
-				It("fetches all the locks corresponding to type code", func() {
-					_, err := locketClient.FetchAll(context.Background(), &models.FetchAllRequest{})
-					Expect(err).To(HaveOccurred())
-				})
-
-				It("fetches all the locks corresponding to type code", func() {
-					response, err := locketClient.FetchAll(context.Background(), &models.FetchAllRequest{Type: models.LockType})
-					Expect(err).NotTo(HaveOccurred())
-					Expect(response.Resources).To(ConsistOf(resource1, resource2))
-				})
-
-				It("fetches all the presences corresponding to type", func() {
-					response, err := locketClient.FetchAll(context.Background(), &models.FetchAllRequest{Type: models.PresenceType})
-					Expect(err).NotTo(HaveOccurred())
-					Expect(response.Resources).To(ConsistOf(resource3, resource4))
-				})
 			})
 
 			Context("when using type code", func() {
@@ -552,7 +527,7 @@ var _ = Describe("Locket", func() {
 				JustBeforeEach(func() {
 					_, err := sqlRunner.DB().Exec("DROP TABLE locks")
 					Expect(err).NotTo(HaveOccurred())
-					_, err = locketClient.FetchAll(context.Background(), &models.FetchAllRequest{Type: models.LockType})
+					_, err = locketClient.FetchAll(context.Background(), &models.FetchAllRequest{TypeCode: models.LOCK})
 					Expect(err).To(HaveOccurred())
 				})
 

--- a/db/lock_db.go
+++ b/db/lock_db.go
@@ -12,7 +12,6 @@ func lagerDataFromLock(resource *models.Resource) lager.Data {
 	return lager.Data{
 		"key":       resource.GetKey(),
 		"owner":     resource.GetOwner(),
-		"type":      resource.GetType(),
 		"type-code": resource.GetTypeCode(),
 	}
 }

--- a/handlers/context_test.go
+++ b/handlers/context_test.go
@@ -66,10 +66,10 @@ var _ = Describe("LocketHandler", func() {
 		exitCh = make(chan struct{}, 1)
 
 		resource = &models.Resource{
-			Key:   "test",
-			Value: "test-value",
-			Owner: "myself",
-			Type:  "lock",
+			Key:      "test",
+			Value:    "test-value",
+			Owner:    "myself",
+			TypeCode: models.LOCK,
 		}
 
 		locketHandler = handlers.NewLocketHandler(

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -146,7 +146,7 @@ func (h *locketHandler) lock(ctx context.Context, req *models.LockRequest) (*mod
 
 	err := validate(req)
 	if err != nil {
-		logger.Error("invalid-request", err, lager.Data{"type": req.Resource.GetType(), "typeCode": req.Resource.GetTypeCode()})
+		logger.Error("invalid-request", err, lager.Data{"typeCode": req.Resource.GetTypeCode()})
 
 		return nil, err
 	}
@@ -224,11 +224,11 @@ func (h *locketHandler) fetchAll(ctx context.Context, req *models.FetchAllReques
 
 	err := validate(req)
 	if err != nil {
-		logger.Error("invalid-request", err, lager.Data{"type": req.GetType(), "typeCode": req.GetTypeCode()})
+		logger.Error("invalid-request", err, lager.Data{"typeCode": req.GetTypeCode()})
 		return nil, err
 	}
 
-	locks, err := h.db.FetchAll(ctx, logger, models.GetType(&models.Resource{Type: req.Type, TypeCode: req.TypeCode}))
+	locks, err := h.db.FetchAll(ctx, logger, models.GetType(&models.Resource{TypeCode: req.TypeCode}))
 	if err != nil {
 		return nil, err
 	}
@@ -244,15 +244,12 @@ func (h *locketHandler) fetchAll(ctx context.Context, req *models.FetchAllReques
 }
 
 func validate(req interface{}) error {
-	var reqType string
 	var reqTypeCode models.TypeCode
 
 	switch incomingReq := req.(type) {
 	case *models.LockRequest:
-		reqType = incomingReq.Resource.GetType()
 		reqTypeCode = incomingReq.Resource.GetTypeCode()
 	case *models.FetchAllRequest:
-		reqType = incomingReq.GetType()
 		reqTypeCode = incomingReq.GetTypeCode()
 	default:
 		return nil
@@ -263,21 +260,7 @@ func validate(req interface{}) error {
 	}
 
 	if reqTypeCode == models.UNKNOWN {
-		if reqType != models.PresenceType && reqType != models.LockType {
-			return models.ErrInvalidType
-		} else {
-			return nil
-		}
-	}
-
-	if reqType != "" {
-		if reqTypeCode == models.LOCK && reqType != models.LockType {
-			return models.ErrInvalidType
-		}
-
-		if reqTypeCode == models.PRESENCE && reqType != models.PresenceType {
-			return models.ErrInvalidType
-		}
+		return models.ErrInvalidType
 	}
 
 	return nil


### PR DESCRIPTION
No longer pay any attention to Resource.Type since it has been deprecated for quite a while. Convert tests to use the TypeCode attribute instead, and update validation/validation test logic.

Thank you for submitting a pull request to the locket repository!

We appreciate the contribution. To help us understand the context for your pull request, please fill out this template to the best of your ability.

## Please make sure to complete all of the following steps

1. Check the [Contributing document](https://github.com/cloudfoundry/diego-release/blob/develop/CONTRIBUTING.md) on how to sign the CLA and run tests.
1. Submit your PR to this repo.
1. [**Submit an accompanying PR Review Request**](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=pr-review-request.md&title=%5BLOCKET+PR+REVIEW%5D%3A) referencing this PR so the Diego Team knows to review your pull request. 
* **Note: this PR will not be reviewed unless you submit the [PR Review Request](https://github.com/cloudfoundry/diego-release/issues/new?assignees=&labels=&template=pr-review-request.md&title=%5BLOCKET+PR+REVIEW%5D%3A)**.

***************************

## Please provide the following information:

### What is this change about?

> _Please describe._

### What problem it is trying to solve?

> _Please describe._

### What is the impact if the change is not made?

> _Please describe._

### How should this change be described in diego-release release notes?

> _Something brief that conveys the change. See [previous release notes](https://github.com/cloudfoundry/diego-release/releases) for examples._

### Please provide any contextual information.

> _Include any links to other PRs, stories, slack discussions, etc._

### Tag your pair, your PM, and/or team!

> _It's helpful to tag someone on your team or your team alias in case we need to follow up later._

Thank you!
