### PR TITLE
Use supported call by grpc-go

### DIFF
--- a/grpcserver/server_test.go
+++ b/grpcserver/server_test.go
@@ -65,7 +65,7 @@ var _ = Describe("GRPCServer", func() {
 		).Client(tlsconfig.WithAuthorityFromFile(caCertFixture))
 		Expect(err).NotTo(HaveOccurred())
 
-		conn, err := grpc.Dial(listenAddress, grpc.WithTransportCredentials(credentials.NewTLS(clientTLSConfig)))
+		conn, err := grpc.NewClient(listenAddress, grpc.WithTransportCredentials(credentials.NewTLS(clientTLSConfig)))
 		Expect(err).NotTo(HaveOccurred())
 
 		locketClient := models.NewLocketClient(conn)

--- a/locket_client.go
+++ b/locket_client.go
@@ -53,10 +53,7 @@ func newClientInternal(logger lager.Logger, config ClientLocketConfig, skipCertV
 	// return a list of addresses. We will also need to add a new NewClient
 	// method that accepts a dialer in order to mock the ipsec (blocking) issue
 	// we ran into in https://www.pivotaltracker.com/story/show/158104990
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	conn, err := grpc.DialContext(ctx,
-		config.LocketAddress,
+	conn, err := grpc.NewClient(config.LocketAddress,
 		grpc.WithTransportCredentials(credentials.NewTLS(locketTLSConfig)),
 		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 			return net.DialTimeout("tcp", addr, 10*time.Second) // give at least 2 seconds per ip address (assuming there are at most 5)


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Context: https://github.com/grpc/grpc-go/pull/7029/files

grpc.DialContext is now removed and replaced by grpc.NewClient. It looks
like grpc.WithContextDialer is suffcient for Timeout purpose.

Backward Compatibility
---------------
Breaking Change? **No**
