### PR TITLE
Remove deprecated usage of WithBlock

### DIFF
--- a/locket_client.go
+++ b/locket_client.go
@@ -61,7 +61,6 @@ func newClientInternal(logger lager.Logger, config ClientLocketConfig, skipCertV
 		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 			return net.DialTimeout("tcp", addr, 10*time.Second) // give at least 2 seconds per ip address (assuming there are at most 5)
 		}),
-		grpc.WithBlock(),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			Time:    time.Duration(config.LocketClientKeepAliveTime) * time.Second,
 			Timeout: time.Duration(config.LocketClientKeepAliveTimeout) * time.Second,


### PR DESCRIPTION
Our linters were flaging the usage of `grpc.WithBlock`. After reviewing [grpc anti-patterns](https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md):
> Some users of Dial use it as a way to validate the configuration of their system. If you wish to maintain this behavior but migrate to NewClient, you can call State and WaitForStateChange until the channel is connected. However, if this fails, it does not mean that your configuration was bad - it could also mean the service is not reachable by the client due to connectivity reasons.

Since we are waiting for state change via `conn.GetState()` in [the for loop at the bottom,](https://github.com/cloudfoundry/locket/compare/grpc_deprecation_fix?expand=1#diff-48e069944e5b0ed631f91f7062b8b3fa9def118f5fa5864aae32f6fc76ade81eR73-R83) and we bail out for any state change funny business with the `if !conn.WaitForStateChange(ctx, s)` conditional, there shouldn't be a need for the `WithBlock()` usage.

