### PR TITLE
Remove old property: loggregator.use_v2_api. It is by default true.

### DIFF
--- a/cmd/locket/config/config_test.go
+++ b/cmd/locket/config/config_test.go
@@ -33,7 +33,6 @@ var _ = Describe("LocketConfig", func() {
 			"sql_enable_identity_verification": true,
       "report_interval":"1s",
 			"loggregator": {
-				"loggregator_use_v2_api": true,
 				"loggregator_api_port": 1234,
 				"loggregator_ca_path": "/var/ca_cert",
 				"loggregator_cert_path": "/var/cert_path",
@@ -83,7 +82,6 @@ var _ = Describe("LocketConfig", func() {
 			SQLCACertFile:                 "/var/vcap/jobs/locket/config/sql.ca",
 			SQLEnableIdentityVerification: true,
 			LoggregatorConfig: loggingclient.Config{
-				UseV2API:   true,
 				APIPort:    1234,
 				CACertPath: "/var/ca_cert",
 				CertPath:   "/var/cert_path",

--- a/cmd/locket/main.go
+++ b/cmd/locket/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"time"
 
@@ -139,15 +140,14 @@ func main() {
 }
 
 func initializeMetron(logger lager.Logger, locketConfig config.LocketConfig) (loggingclient.IngressClient, error) {
+	fmt.Println("** Get metron client")
 	client, err := loggingclient.NewIngressClient(locketConfig.LoggregatorConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	if locketConfig.LoggregatorConfig.UseV2API {
-		emitter := runtimeemitter.NewV1(client)
-		go emitter.Run()
-	}
+	emitter := runtimeemitter.NewV1(client)
+	go emitter.Run()
 
 	return client, nil
 }

--- a/cmd/locket/main_test.go
+++ b/cmd/locket/main_test.go
@@ -70,7 +70,6 @@ var _ = Describe("Locket", func() {
 				port, err := portAllocator.ClaimPorts(1)
 				Expect(err).NotTo(HaveOccurred())
 				configOverrides = append(configOverrides, func(cfg *config.LocketConfig) {
-					cfg.LoggregatorConfig.UseV2API = true
 					cfg.LoggregatorConfig.APIPort = int(port)
 					cfg.LoggregatorConfig.CACertPath = "fixtures/metron/CA.crt"
 					cfg.LoggregatorConfig.KeyPath = "fixtures/metron/client.key"
@@ -158,7 +157,6 @@ var _ = Describe("Locket", func() {
 			Context("when using the v2 api", func() {
 				BeforeEach(func() {
 					configOverrides = append(configOverrides, func(cfg *config.LocketConfig) {
-						cfg.LoggregatorConfig.UseV2API = true
 						cfg.LoggregatorConfig.APIPort = testMetricsPort
 						cfg.LoggregatorConfig.CACertPath = "fixtures/metron/CA.crt"
 						cfg.LoggregatorConfig.KeyPath = "fixtures/metron/client.key"
@@ -289,7 +287,6 @@ var _ = Describe("Locket", func() {
 			Context("when not using the v2 api", func() {
 				BeforeEach(func() {
 					configOverrides = append(configOverrides, func(cfg *config.LocketConfig) {
-						cfg.LoggregatorConfig.UseV2API = false
 						cfg.LoggregatorConfig.APIPort = testMetricsPort
 						cfg.LoggregatorConfig.CACertPath = "fixtures/metron/CA.crt"
 						cfg.LoggregatorConfig.KeyPath = "fixtures/metron/client.key"


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Remove old property: loggregator.use_v2_api. It is by default true.




Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
