### PR TITLE
Configurable db connection timeout settings

### DIFF
--- a/cmd/locket/main.go
+++ b/cmd/locket/main.go
@@ -53,12 +53,19 @@ func main() {
 
 	clock := clock.NewClock()
 
+	dbParams := &helpers.BBSDBParam{
+		DriverName:                    cfg.DatabaseDriver,
+		DatabaseConnectionString:      cfg.DatabaseConnectionString,
+		SqlCACertFile:                 cfg.SQLCACertFile,
+		SqlEnableIdentityVerification: cfg.SQLEnableIdentityVerification,
+		ConnectionTimeout:             time.Duration(600),
+		ReadTimeout:                   time.Duration(600),
+		WriteTimeout:                  time.Duration(600),
+	}
+
 	sqlConn, err := helpers.Connect(
 		logger,
-		cfg.DatabaseDriver,
-		cfg.DatabaseConnectionString,
-		cfg.SQLCACertFile,
-		cfg.SQLEnableIdentityVerification,
+		dbParams,
 	)
 
 	if err != nil {

--- a/cmd/locket/main.go
+++ b/cmd/locket/main.go
@@ -58,9 +58,6 @@ func main() {
 		DatabaseConnectionString:      cfg.DatabaseConnectionString,
 		SqlCACertFile:                 cfg.SQLCACertFile,
 		SqlEnableIdentityVerification: cfg.SQLEnableIdentityVerification,
-		ConnectionTimeout:             time.Duration(600),
-		ReadTimeout:                   time.Duration(600),
-		WriteTimeout:                  time.Duration(600),
 	}
 
 	sqlConn, err := helpers.Connect(

--- a/db/sqldb_suite_test.go
+++ b/db/sqldb_suite_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
-	"time"
 
 	"code.cloudfoundry.org/bbs/db/sqldb/helpers"
 	"code.cloudfoundry.org/bbs/db/sqldb/helpers/monitor"
@@ -77,9 +76,6 @@ var _ = BeforeSuite(func() {
 		DatabaseConnectionString:      dbBaseConnectionString,
 		SqlCACertFile:                 "",
 		SqlEnableIdentityVerification: false,
-		ConnectionTimeout:             time.Duration(600),
-		ReadTimeout:                   time.Duration(600),
-		WriteTimeout:                  time.Duration(600),
 	}
 	rawDB, err = helpers.Connect(logger, dbParams)
 

--- a/handlers/context_test.go
+++ b/handlers/context_test.go
@@ -51,9 +51,6 @@ var _ = Describe("LocketHandler", func() {
 			DatabaseConnectionString:      sqlRunner.ConnectionString(),
 			SqlCACertFile:                 "",
 			SqlEnableIdentityVerification: false,
-			ConnectionTimeout:             time.Duration(600),
-			ReadTimeout:                   time.Duration(600),
-			WriteTimeout:                  time.Duration(600),
 		}
 		sqlConn, err = helpers.Connect(logger, dbParams)
 		Expect(err).NotTo(HaveOccurred())

--- a/handlers/context_test.go
+++ b/handlers/context_test.go
@@ -46,7 +46,16 @@ var _ = Describe("LocketHandler", func() {
 		sqlProcess = ginkgomon.Invoke(sqlRunner)
 
 		var err error
-		sqlConn, err = helpers.Connect(logger, sqlRunner.DriverName(), sqlRunner.ConnectionString(), "", false)
+		dbParams := &helpers.BBSDBParam{
+			DriverName:                    sqlRunner.DriverName(),
+			DatabaseConnectionString:      sqlRunner.ConnectionString(),
+			SqlCACertFile:                 "",
+			SqlEnableIdentityVerification: false,
+			ConnectionTimeout:             time.Duration(600),
+			ReadTimeout:                   time.Duration(600),
+			WriteTimeout:                  time.Duration(600),
+		}
+		sqlConn, err = helpers.Connect(logger, dbParams)
 		Expect(err).NotTo(HaveOccurred())
 
 		dbMonitor := monitor.New()


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Configurable db connection timeout settings

```
~/workspace/diego-release |TNZ-60737-1 U:7?:1| 
$ ./scripts/test-in-docker.bash locket
Succeeded
Using default tag: latest
latest: Pulling from cloudfoundry/tas-runtime-mysql-8.0
Digest: sha256:69bf91c0f6c39944f6ad791d6dc27292f9d3180a62e29c57d392724b7dd22557
Status: Image is up to date for cloudfoundry/tas-runtime-mysql-8.0:latest
docker.io/cloudfoundry/tas-runtime-mysql-8.0:latest
diego-release-mysql-docker-container
8117eec816acdb46ef1e34986bed3dd2c6120bcc5119dbe1697a428631b3eb61
locket
go version go1.25.2 linux/amd64
/repo/src/code.cloudfoundry.org/vendor/github.com/nats-io/nats-server/v2 /
/
/tmp/build-proxy-dXMw /
/
Don't run Bundler as root. Installing your bundle as root will break this
application for all non-root users on this machine.
Fetching gem metadata from https://rubygems.org/...........
Fetching semi_semantic 1.2.0
Fetching ast 2.4.2
Installing semi_semantic 1.2.0
Installing ast 2.4.2
Using bundler 2.4.10
Fetching diff-lcs 1.5.1
Fetching json 2.9.0
Installing diff-lcs 1.5.1
Installing json 2.9.0 with native extensions
Fetching language_server-protocol 3.17.0.3
Installing language_server-protocol 3.17.0.3
Fetching parallel 1.26.3
Installing parallel 1.26.3
Fetching racc 1.8.1
Installing racc 1.8.1 with native extensions
Fetching rainbow 3.1.1
Installing rainbow 3.1.1
Fetching regexp_parser 2.9.3
Installing regexp_parser 2.9.3
Fetching rspec-support 3.13.2
Installing rspec-support 3.13.2
Fetching ruby-progressbar 1.13.0
Installing ruby-progressbar 1.13.0
Fetching unicode-emoji 4.0.4
Installing unicode-emoji 4.0.4
Fetching bosh-template 2.4.0
Installing bosh-template 2.4.0
Fetching parser 3.3.6.0
Installing parser 3.3.6.0
Fetching rspec-core 3.13.2
Installing rspec-core 3.13.2
Fetching rspec-expectations 3.13.3
Installing rspec-expectations 3.13.3
Fetching rspec-mocks 3.13.2
Installing rspec-mocks 3.13.2
Fetching unicode-display_width 3.1.2
Installing unicode-display_width 3.1.2
Fetching rubocop-ast 1.36.2
Installing rubocop-ast 1.36.2
Fetching rspec 3.13.0
Installing rspec 3.13.0
Fetching rubocop 1.69.1
Installing rubocop 1.69.1
Bundle complete! 3 Gemfile dependencies, 22 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
..........................

Finished in 0.18674 seconds (files took 0.14069 seconds to load)
26 examples, 0 failures

Running ./ci/diego-release/linters/sync-package-specs.bash for-diego-release with-exit-on-error=true
:100755 100755 d39545ee6fd4e26fd99c275293455e81b3cdf856 0000000000000000000000000000000000000000 M	scripts/test-in-docker.bash
There are unstaged changes in the index!
Sourcing: built-binaries/proxy/run.bash
Sourcing: built-binaries/nats-server/run.bash
Setting env: DB_USER
Setting env: DB_PASSWORD
Verifying: verify_go repo/src/code.cloudfoundry.org/locket
go version go1.25.2 linux/amd64
booting mysql.............connection established to mysql
[1760032622] Locket Suite - 20/20 specs - 7 procs •••••••••••••••••••• SUCCESS! 24.686424178s 
[1760032622] Certauthority Suite - 6/6 specs - 7 procs •••••• SUCCESS! 9.754482132s 
[1760032622] Config Suite - 3/3 specs - 7 procs ••• SUCCESS! 50.334898ms 
[1760032622] SQL DB Suite - 31/31 specs - 7 procs ••••••••••••••••••••••••••••••• SUCCESS! 1.058634163s 
[1760032622] Expiration Suite - 18/18 specs - 7 procs •••••••••••••••••• SUCCESS! 312.900392ms 
[1760032622] Grpcserver Suite - 2/2 specs - 7 procs •• SUCCESS! 105.82984ms 
[1760032622] Handlers Suite - 49/49 specs - 7 procs ••••••••••••••••••••••••••••••••••••••••••••••••• SUCCESS! 339.522996ms 
[1760032622] Jointlock Suite - 15/15 specs - 7 procs ••••••••••••••• SUCCESS! 499.080638ms 
[1760032622] Lock Suite - 21/21 specs - 7 procs ••••••••••••••••••••• SUCCESS! 300.921807ms 
[1760032622] Lockheldmetrics Suite - 2/2 specs - 7 procs •• SUCCESS! 88.948351ms 
[1760032622] Metrics Suite - 11/11 specs - 7 procs ••••••••••• SUCCESS! 346.045902ms 
[1760032622] Metrics Helpers Suite - 19/19 specs - 7 procs ••••••••••••••••••• SUCCESS! 477.801374ms 
[1760032622] Models Suite - 4/4 specs - 7 procs •••• SUCCESS! 83.844197ms 

Ginkgo ran 13 suites in 2m28.892692313s
Test Suite Passed
```


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
