### PR TITLE
update dbconnection param for postgres test

### DIFF
--- a/db/sqldb_suite_test.go
+++ b/db/sqldb_suite_test.go
@@ -119,6 +119,7 @@ var _ = AfterEach(func() {
 
 var _ = AfterSuite(func() {
 	Expect(rawDB.Close()).NotTo(HaveOccurred())
+	dbParams.DatabaseConnectionString = dbBaseConnectionString
 	rawDB, err := helpers.Connect(logger, dbParams)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(rawDB.Ping()).NotTo(HaveOccurred())


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Adjust db connection param for the sq suite test

```
~/workspace/diego-release/src/code.cloudfoundry.org/locket |db-conn-param ?:1| 
$ docker exec -it 9e2 /bin/bash
root@9e23b3d331a3:/# 
(failed reverse-i-search)`./re': ^C
root@9e23b3d331a3:/# ./repo/scripts/docker/test.bash locket
Sourcing: built-binaries/proxy/run.bash
Sourcing: built-binaries/nats-server/run.bash
Setting env: DB_USER
Setting env: DB_PASSWORD
Verifying: verify_go repo/src/code.cloudfoundry.org/locket
go version go1.25.3 linux/amd64
Verifying: verify_go_version_match_bosh_release repo
Verifying: verify_gofmt repo/src/code.cloudfoundry.org/locket
Verifying: verify_govet repo/src/code.cloudfoundry.org/locket
Verifying: verify_staticcheck repo/src/code.cloudfoundry.org/locket
booting postgres..connection established to postgres
[1760481162] Locket Suite - 20/20 specs - 7 procs •••••••••••••••••••• SUCCESS! 22.420170095s 
[1760481162] Certauthority Suite - 6/6 specs - 7 procs •••••• SUCCESS! 11.517751488s 
[1760481162] Config Suite - 3/3 specs - 7 procs ••• SUCCESS! 19.23746ms 
[1760481162] SQL DB Suite - 31/31 specs - 7 procs ••••••••••••••••••••••••••••••• SUCCESS! 541.847111ms 
[1760481162] Expiration Suite - 18/18 specs - 7 procs •••••••••••••••••• SUCCESS! 296.128405ms 
[1760481162] Grpcserver Suite - 2/2 specs - 7 procs •• SUCCESS! 1.569729891s 
[1760481162] Handlers Suite - 49/49 specs - 7 procs ••••••••••••••••••••••••••••••••••••••••••••••••• SUCCESS! 245.901886ms 
[1760481162] Jointlock Suite - 15/15 specs - 7 procs ••••••••••••••• SUCCESS! 386.871472ms 
[1760481162] Lock Suite - 21/21 specs - 7 procs ••••••••••••••••••••• SUCCESS! 284.085334ms 
[1760481162] Lockheldmetrics Suite - 2/2 specs - 7 procs •• SUCCESS! 76.093042ms 
[1760481162] Metrics Suite - 11/11 specs - 7 procs ••••••••••• SUCCESS! 335.313904ms 
[1760481162] Metrics Helpers Suite - 19/19 specs - 7 procs ••••••••••••••••••• SUCCESS! 505.23274ms 
[1760481162] Models Suite - 4/4 specs - 7 procs •••• SUCCESS! 67.484516ms 

Ginkgo ran 13 suites in 2m17.809159098s
Test Suite Passed
```

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
