### PR TITLE
Locket Presence Runner should use retry interval for timeout and not TTL

### DIFF
--- a/lock/lock.go
+++ b/lock/lock.go
@@ -127,7 +127,7 @@ func (l *lockRunner) Run(signals <-chan os.Signal, ready chan<- struct{}) error 
 				logger.Error("failed-to-create-context", err)
 				return err
 			}
-			ctx, cancel := context.WithTimeout(ctx, time.Duration(l.ttlInSeconds)*time.Second)
+			ctx, cancel := context.WithTimeout(ctx, time.Duration(l.retryInterval)*time.Second)
 			start := time.Now()
 			_, err = l.locker.Lock(ctx, &models.LockRequest{Resource: l.lock, TtlInSeconds: l.ttlInSeconds}, grpc.WaitForReady(true))
 			cancel()


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Locket Presence Runner should use retry interval for timeout and not TTL

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
