### PR TITLE
add metron server config - fix dep

### DIFF
--- a/cmd/locket/main_test.go
+++ b/cmd/locket/main_test.go
@@ -11,7 +11,6 @@ import (
 
 	"code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/durationjson"
-	"code.cloudfoundry.org/fixtures"
 	"code.cloudfoundry.org/go-loggregator/v9/rpc/loggregator_v2"
 	"code.cloudfoundry.org/lager/v3/lagertest"
 	"code.cloudfoundry.org/locket"
@@ -57,10 +56,10 @@ var _ = Describe("Locket", func() {
 				cfg.DatabaseDriver = sqlRunner.DriverName()
 				cfg.DatabaseConnectionString = sqlRunner.ConnectionString()
 				cfg.ReportInterval = durationjson.Duration(time.Second)
-				cfg.LoggregatorConfig.APIPort = metronIngressSetup.Port
-				cfg.LoggregatorConfig.CACertPath = fixtures.Path("CA.crt")
-				cfg.LoggregatorConfig.CertPath = fixtures.Path("metron.crt")
-				cfg.LoggregatorConfig.KeyPath = fixtures.Path("metron.key")
+				cfg.LoggregatorConfig.APIPort, _ = testIngressServer.Port()
+				cfg.LoggregatorConfig.CACertPath = metronCAFile
+				cfg.LoggregatorConfig.CertPath = metronServerCertFile
+				cfg.LoggregatorConfig.KeyPath = metronServerKeyFile
 			},
 		}
 	})
@@ -76,9 +75,9 @@ var _ = Describe("Locket", func() {
 				Expect(err).NotTo(HaveOccurred())
 				configOverrides = append(configOverrides, func(cfg *config.LocketConfig) {
 					cfg.LoggregatorConfig.APIPort = int(port)
-					cfg.LoggregatorConfig.CACertPath = fixtures.Path("CA.crt")
-					cfg.LoggregatorConfig.CertPath = fixtures.Path("metron.crt")
-					cfg.LoggregatorConfig.KeyPath = fixtures.Path("metron.key")
+					cfg.LoggregatorConfig.CACertPath = metronCAFile
+					cfg.LoggregatorConfig.CertPath = metronServerCertFile
+					cfg.LoggregatorConfig.KeyPath = metronServerKeyFile
 				})
 			})
 


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

```
root@eb9689e0c1a9:/repo/src/code.cloudfoundry.org/locket# git log --oneline | head -1
f082ec2 add metron server config
root@eb9689e0c1a9:/repo/src/code.cloudfoundry.org/locket# cd ../../..
root@eb9689e0c1a9:/repo# ./scripts/docker/test.bash locket
Sourcing: built-binaries/proxy/run.bash
Sourcing: built-binaries/nats-server/run.bash
Setting env: DB_USER
Setting env: DB_PASSWORD
Verifying: verify_go repo/src/code.cloudfoundry.org/locket
go version go1.25.3 linux/amd64
Verifying: verify_go_version_match_bosh_release repo
Verifying: verify_gofmt repo/src/code.cloudfoundry.org/locket
Verifying: verify_govet repo/src/code.cloudfoundry.org/locket
Verifying: verify_staticcheck repo/src/code.cloudfoundry.org/locket
booting mysqlconnection established to mysql
[1761662659] Locket Suite - 19/19 specs - 7 procs ••••••••••••••••••• SUCCESS! 21.849333131s 
[1761662659] Certauthority Suite - 6/6 specs - 7 procs •••••• SUCCESS! 10.192717471s 
[1761662659] Config Suite - 3/3 specs - 7 procs ••• SUCCESS! 87.592883ms 
[1761662659] SQL DB Suite - 31/31 specs - 7 procs ••••••••••••••••••••••••••••••• SUCCESS! 545.663668ms 
[1761662659] Expiration Suite - 18/18 specs - 7 procs •••••••••••••••••• SUCCESS! 329.071567ms 
[1761662659] Grpcserver Suite - 2/2 specs - 7 procs •• SUCCESS! 101.6183ms 
[1761662659] Handlers Suite - 49/49 specs - 7 procs ••••••••••••••••••••••••••••••••••••••••••••••••• SUCCESS! 252.179216ms 
[1761662659] Jointlock Suite - 15/15 specs - 7 procs ••••••••••••••• SUCCESS! 385.435527ms 
[1761662659] Lock Suite - 21/21 specs - 7 procs ••••••••••••••••••••• SUCCESS! 351.690217ms 
[1761662659] Lockheldmetrics Suite - 2/2 specs - 7 procs •• SUCCESS! 75.072838ms 
[1761662659] Metrics Suite - 11/11 specs - 7 procs ••••••••••• SUCCESS! 292.288112ms 
[1761662659] Metrics Helpers Suite - 19/19 specs - 7 procs ••••••••••••••••••• SUCCESS! 469.485681ms 
[1761662659] Models Suite - 4/4 specs - 7 procs •••• SUCCESS! 50.960482ms 

Ginkgo ran 13 suites in 1m10.571786194s
Test Suite Passed
```

Test go mod:
```
➜  code.cloudfoundry.org git:(develop) ✗ go mod tidy
go: finding module for package code.cloudfoundry.org/fixtures
go: code.cloudfoundry.org/tools imports
        code.cloudfoundry.org/locket/cmd/locket tested by
        code.cloudfoundry.org/locket/cmd/locket.test imports
        code.cloudfoundry.org/fixtures: cannot find module providing package code.cloudfoundry.org/fixtures: unrecognized import path "code.cloudfoundry.org/fixtures": reading https://code.cloudfoundry.org/fixtures?go-get=1: 404 Not Found

After pointing to commit:
	code.cloudfoundry.org/locket => github.com/kart2bc/locket v0.0.0-20251028143205-f082ec29d3e2
➜  code.cloudfoundry.org git:(develop) ✗ go mod tidy
➜  code.cloudfoundry.org git:(develop) ✗ git log --oneline      
```

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
