### PR TITLE
Retry interval is already a time Duration

### DIFF
--- a/lock/lock.go
+++ b/lock/lock.go
@@ -127,7 +127,7 @@ func (l *lockRunner) Run(signals <-chan os.Signal, ready chan<- struct{}) error 
 				logger.Error("failed-to-create-context", err)
 				return err
 			}
-			ctx, cancel := context.WithTimeout(ctx, time.Duration(l.retryInterval)*time.Second)
+			ctx, cancel := context.WithTimeout(ctx, l.retryInterval)
 			start := time.Now()
 			_, err = l.locker.Lock(ctx, &models.LockRequest{Resource: l.lock, TtlInSeconds: l.ttlInSeconds}, grpc.WaitForReady(true))
 			cancel()


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Retry interval is already in time.Duration and we don't need to divide it by seconds


Backward Compatibility
---------------
Breaking Change? **No**
