### PR TITLE
Add configurable database health check with automatic restart on failure

### DIFF
--- a/cmd/locket/config/config.go
+++ b/cmd/locket/config/config.go
@@ -26,6 +26,10 @@ type LocketConfig struct {
 	SQLEnableIdentityVerification bool                  `json:"sql_enable_identity_verification,omitempty"`
 	LoggregatorConfig             loggingclient.Config  `json:"loggregator"`
 	ReportInterval                durationjson.Duration `json:"report_interval,omitempty"`
+	HealthCheckTimeout            durationjson.Duration `json:"health_check_timeout,omitempty"`
+	HealthCheckFailureThreshold   int                   `json:"health_check_failure_threshold,omitempty"`
+	HealthCheckInterval           durationjson.Duration `json:"health_check_interval,omitempty"`
+	EnableDBHealthCheck           bool                  `json:"enable_db_health_check,omitempty"`
 	debugserver.DebugServerConfig
 	lagerflags.LagerConfig
 }

--- a/cmd/locket/db_health_check_runner.go
+++ b/cmd/locket/db_health_check_runner.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"code.cloudfoundry.org/clock"
+	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/locket/db"
+)
+
+type DBHealthCheckRunner struct {
+	logger                      lager.Logger
+	sqlDB                       db.LocketHealthCheckDB
+	clock                       clock.Clock
+	lock                        sync.Mutex
+	isRunning                   bool
+	HealthCheckFailureThreshold int
+	HealthCheckTimeout          time.Duration
+	HealthCheckInterval         time.Duration
+}
+
+func NewDBHealthCheckRunner(logger lager.Logger, sqlDB db.LocketHealthCheckDB, clock clock.Clock, failureCount int, timeout, interval time.Duration) *DBHealthCheckRunner {
+	if failureCount == 0 {
+		failureCount = 3
+	}
+	if timeout == 0 {
+		timeout = 5 * time.Second
+	}
+	if interval == 0 {
+		interval = 10 * time.Second
+	}
+	return &DBHealthCheckRunner{
+		logger:                      logger.Session("db-health-check-runner"),
+		sqlDB:                       sqlDB,
+		clock:                       clock,
+		HealthCheckFailureThreshold: failureCount,
+		HealthCheckTimeout:          timeout,
+		HealthCheckInterval:         interval,
+		lock:                        sync.Mutex{},
+	}
+}
+
+func (runner *DBHealthCheckRunner) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
+	close(ready)
+	runner.logger.Info("starting")
+	defer runner.logger.Info("exiting")
+
+	ticker := runner.clock.NewTicker(runner.HealthCheckInterval)
+	healthCheckResults := make(chan error)
+	for {
+		runner.logger.Debug("reentering-run-loop")
+		select {
+		case err := <-healthCheckResults:
+			runner.lock.Lock()
+			runner.isRunning = false
+			runner.lock.Unlock()
+			if err != nil {
+				runner.logger.Error("database-failure-detected-restarting-locket", err)
+				return err
+			}
+			runner.logger.Debug("health-check-succeeded")
+		case <-signals:
+			runner.logger.Debug("exiting-due-to-signal")
+			return nil
+		case <-ticker.C():
+			runner.lock.Lock()
+			if !runner.isRunning {
+				runner.isRunning = true
+				runner.logger.Debug("executing-health-check")
+				go runner.ExecuteTimedHealthCheckWithRetries(healthCheckResults)
+			}
+			runner.lock.Unlock()
+		}
+	}
+}
+
+func (runner *DBHealthCheckRunner) ExecuteTimedHealthCheckWithRetries(resultChan chan error) {
+	var errs []error
+	for i := 1; i <= runner.HealthCheckFailureThreshold; i++ {
+		logger := runner.logger.WithData(lager.Data{"attempt": i})
+		logger.Debug("executing-timed-health-check")
+		err := runner.ExecuteTimedHealthCheck()
+		if err != nil {
+			logger.Error("failed-health-check", err)
+			errs = append(errs, err)
+		} else {
+			resultChan <- nil
+			return
+		}
+	}
+	finalErr := errors.Join(errs...)
+	runner.logger.Error("health-check-attempts-exceeded", finalErr, lager.Data{"max-attempts": runner.HealthCheckFailureThreshold})
+	resultChan <- finalErr
+}
+
+func (runner *DBHealthCheckRunner) ExecuteTimedHealthCheck() error {
+	timer := runner.clock.NewTimer(runner.HealthCheckTimeout)
+	errChan := make(chan error)
+	go runner.runDBHealthCheck(errChan)
+
+	select {
+	case err := <-errChan:
+		if err == nil {
+			return nil
+		} else {
+			return err
+		}
+	case <-timer.C():
+		err := fmt.Errorf("timed out after %s while executing DB health check", runner.HealthCheckTimeout)
+		runner.logger.Error("health-check-timed-out", err)
+		return err
+	}
+}
+
+func (runner *DBHealthCheckRunner) runDBHealthCheck(errChan chan error) {
+	err := runner.sqlDB.PerformLocketHealthCheck(context.Background(), runner.logger, time.Now())
+	errChan <- err
+}

--- a/cmd/locket/db_health_check_runner.go
+++ b/cmd/locket/db_health_check_runner.go
@@ -63,9 +63,9 @@ func (runner *DBHealthCheckRunner) Run(signals <-chan os.Signal, ready chan<- st
 				runner.logger.Error("database-failure-detected-restarting-locket", err)
 				return err
 			}
-			runner.logger.Debug("health-check-succeeded")
+			runner.logger.Info("health-check-succeeded")
 		case <-signals:
-			runner.logger.Debug("exiting-due-to-signal")
+			runner.logger.Info("exiting-due-to-signal")
 			return nil
 		case <-ticker.C():
 			runner.lock.Lock()

--- a/cmd/locket/db_health_check_runner_test.go
+++ b/cmd/locket/db_health_check_runner_test.go
@@ -1,0 +1,191 @@
+package main_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/tedsuo/ifrit"
+	ginkgomon "github.com/tedsuo/ifrit/ginkgomon_v2"
+
+	locket "code.cloudfoundry.org/locket/cmd/locket"
+	"code.cloudfoundry.org/locket/db/dbfakes"
+	"code.cloudfoundry.org/clock/fakeclock"
+	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/lager/v3/lagertest"
+)
+
+var _ = Describe("DBHealthCheckRunner", func() {
+	var (
+		fakeClock  *fakeclock.FakeClock
+		fakeDB     *dbfakes.FakeLocketHealthCheckDB
+		fakeLogger *lagertest.TestLogger
+		runner     *locket.DBHealthCheckRunner
+		process    ifrit.Process
+	)
+	BeforeEach(func() {
+		fakeClock = fakeclock.NewFakeClock(time.Now())
+		fakeLogger = lagertest.NewTestLogger("test")
+		fakeDB = &dbfakes.FakeLocketHealthCheckDB{}
+		fakeDB.PerformLocketHealthCheckReturns(nil)
+		runner = locket.NewDBHealthCheckRunner(fakeLogger, fakeDB, fakeClock, 4, 100*time.Millisecond, 200*time.Millisecond)
+	})
+	JustBeforeEach(func() {
+		process = ginkgomon.Invoke(runner)
+		Eventually(fakeLogger).Should(gbytes.Say("reentering-run-loop"))
+	})
+	AfterEach(func() {
+		ginkgomon.Kill(process)
+		waitCh := process.Wait()
+		Eventually(waitCh).Should(Receive())
+	})
+
+	Context("when using empty values for health check settings", func() {
+		BeforeEach(func() {
+			runner = locket.NewDBHealthCheckRunner(fakeLogger, fakeDB, fakeClock, 0, 0, 0)
+		})
+		It("sets default values", func() {
+			Expect(runner.HealthCheckFailureThreshold).To(Equal(3))
+			Expect(runner.HealthCheckTimeout).To(Equal(5 * time.Second))
+			Expect(runner.HealthCheckInterval).To(Equal(10 * time.Second))
+		})
+		It("queries PerformLocketHealthCheck() every interval", func() {
+			callCount := fakeDB.PerformLocketHealthCheckCallCount()
+			fakeClock.IncrementBySeconds(11)
+			Eventually(fakeDB.PerformLocketHealthCheckCallCount).Should(BeNumerically(">", callCount))
+			fakeClock.IncrementBySeconds(11)
+			Eventually(fakeDB.PerformLocketHealthCheckCallCount).Should(BeNumerically(">", callCount+1))
+		})
+	})
+
+	It("queries PerformLocketHealthCheck() every interval", func() {
+		callCount := fakeDB.PerformLocketHealthCheckCallCount()
+		fakeClock.Increment(201 * time.Millisecond)
+		Eventually(fakeDB.PerformLocketHealthCheckCallCount).Should(BeNumerically(">", callCount))
+		Eventually(fakeLogger).Should(gbytes.Say("health-check-succeeded"))
+		fakeClock.Increment(201 * time.Millisecond)
+		Eventually(fakeDB.PerformLocketHealthCheckCallCount).Should(BeNumerically(">", callCount+1))
+	})
+	Context("when signaled", func() {
+		It("exits without an error", func() {
+			ginkgomon.Interrupt(process)
+			waitCh := process.Wait()
+			Eventually(func(g Gomega) {
+				err := <-waitCh
+				g.Expect(err).ToNot(HaveOccurred())
+			}).Should(Succeed())
+			Consistently(fakeLogger).ShouldNot(gbytes.Say("database-failure-detected-restarting-locket"))
+		})
+	})
+	Context("and the health check is hanging up to the timeout", func() {
+		BeforeEach(func() {
+			runner.HealthCheckTimeout = 200 * time.Millisecond
+			runner.HealthCheckInterval = 100 * time.Millisecond
+			fakeDB.PerformLocketHealthCheckCalls(func(ctx context.Context, logger lager.Logger, t time.Time) error {
+				time.Sleep(200 * time.Second)
+				return nil
+			})
+		})
+		It("only runs one health check at a time", func() {
+			waitCh := process.Wait()
+			fakeClock.Increment(100 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
+			fakeClock.Increment(100 * time.Millisecond)
+			Consistently(waitCh, "300ms").ShouldNot(Receive())
+			Expect(fakeDB.PerformLocketHealthCheckCallCount()).To(Equal(1))
+		})
+		Context("and it is signalled", func() {
+			It("processes the signal immediately", func() {
+				ginkgomon.Interrupt(process)
+				waitCh := process.Wait()
+				Eventually(func(g Gomega) {
+					err := <-waitCh
+					g.Expect(err).ToNot(HaveOccurred())
+				}, "100ms").Should(Succeed())
+
+			})
+		})
+	})
+	Context("ExecuteTimedHealthCheckWithRetries()", func() {
+		Context("when PerformLocketHealthCheck() fails", func() {
+			Context("the entire time", func() {
+				BeforeEach(func() {
+					fakeDB.PerformLocketHealthCheckReturns(fmt.Errorf("meow"))
+				})
+				It("returns an error", func() {
+					fakeClock.IncrementBySeconds(2)
+					waitCh := process.Wait()
+					Eventually(waitCh).Should(Receive(MatchError("meow\nmeow\nmeow\nmeow")))
+					Eventually(fakeLogger).Should(gbytes.Say("database-failure-detected-restarting-locket"))
+					Expect(fakeDB.PerformLocketHealthCheckCallCount()).To(Equal(4))
+
+				})
+			})
+			Context("only twice and then succeeds", func() {
+				BeforeEach(func() {
+					fakeDB.PerformLocketHealthCheckReturnsOnCall(0, fmt.Errorf("meow"))
+					fakeDB.PerformLocketHealthCheckReturnsOnCall(1, fmt.Errorf("meow"))
+					fakeDB.PerformLocketHealthCheckReturnsOnCall(2, nil)
+				})
+				It("returns a success", func() {
+					fakeClock.IncrementBySeconds(15)
+					waitCh := process.Wait()
+					Consistently(waitCh).ShouldNot(Receive())
+					Eventually(fakeLogger).Should(gbytes.Say("health-check-succeeded"))
+				})
+			})
+		})
+	})
+	Describe("ExecuteTimedHealthCheck()", func() {
+		Context("when PerformLocketHealthCheck returns an error", func() {
+			BeforeEach(func() {
+				fakeDB.PerformLocketHealthCheckReturns(fmt.Errorf("meow"))
+			})
+			It("fails", func() {
+				err := runner.ExecuteTimedHealthCheck()
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError("meow"))
+			})
+		})
+		Context("when PerformLocketHealthCheck succeeds", func() {
+			It("succeeds", func() {
+				err := runner.ExecuteTimedHealthCheck()
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+		Context("when PerformLocketHealthCheck takes > the timeout", func() {
+			BeforeEach(func() {
+				fakeDB.PerformLocketHealthCheckCalls(func(ctx context.Context, logger lager.Logger, t time.Time) error {
+					fakeClock.Increment(200 * time.Millisecond)
+					time.Sleep(200 * time.Millisecond)
+					return nil
+				})
+			})
+
+			It("returns an error", func() {
+				err := runner.ExecuteTimedHealthCheck()
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError("timed out after 100ms while executing DB health check"))
+
+			})
+			Context("when using the default timeout", func() {
+				BeforeEach(func() {
+					runner = locket.NewDBHealthCheckRunner(fakeLogger, fakeDB, fakeClock, 0, 0, 0)
+					fakeDB.PerformLocketHealthCheckCalls(func(ctx context.Context, logger lager.Logger, t time.Time) error {
+						fakeClock.Increment(6 * time.Second)
+						time.Sleep(200 * time.Millisecond)
+						return nil
+					})
+				})
+				It("returns an error", func() {
+					err := runner.ExecuteTimedHealthCheck()
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError("timed out after 5s while executing DB health check"))
+				})
+			})
+		})
+	})
+})

--- a/cmd/locket/main.go
+++ b/cmd/locket/main.go
@@ -97,6 +97,13 @@ func main() {
 		logger.Fatal("failed-to-create-lock-table", err)
 	}
 
+	if cfg.EnableDBHealthCheck {
+		err = sqlDB.CreateHealthCheckTable(context.Background(), logger)
+		if err != nil {
+			logger.Fatal("failed-to-create-health-check-table", err)
+		}
+	}
+
 	tlsConfig, err := tlsconfig.Build(
 		tlsconfig.WithInternalServiceDefaults(),
 		tlsconfig.WithIdentityFromFile(cfg.CertFile, cfg.KeyFile),
@@ -114,12 +121,30 @@ func main() {
 	handler := handlers.NewLocketHandler(logger, sqlDB, lockPick, requestNotifier, exitCh)
 	server := grpcserver.NewGRPCServer(logger, cfg.ListenAddress, tlsConfig, handler)
 
+	var dbHealthCheckRunner ifrit.Runner
+	if cfg.EnableDBHealthCheck {
+		dbHealthCheckRunner = NewDBHealthCheckRunner(
+			logger,
+			sqlDB,
+			clock,
+			cfg.HealthCheckFailureThreshold,
+			time.Duration(cfg.HealthCheckTimeout),
+			time.Duration(cfg.HealthCheckInterval),
+		)
+	}
+
 	members := grouper.Members{
 		{Name: "server", Runner: server},
 		{Name: "burglar", Runner: burglar},
 		{Name: "lock-metrics-notifier", Runner: lockMetricsNotifier},
 		{Name: "db-metrics-notifier", Runner: dbMetricsNotifier},
 		{Name: "request-metrics-notifier", Runner: requestNotifier},
+	}
+
+	if cfg.EnableDBHealthCheck {
+		members = append(grouper.Members{
+			{Name: "db-health-check", Runner: dbHealthCheckRunner},
+		}, members...)
 	}
 
 	if cfg.DebugAddress != "" {

--- a/db/locket_health_check.go
+++ b/db/locket_health_check.go
@@ -1,0 +1,46 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"code.cloudfoundry.org/bbs/db/sqldb/helpers"
+	"code.cloudfoundry.org/lager/v3"
+)
+
+//go:generate counterfeiter . LocketHealthCheckDB
+
+type LocketHealthCheckDB interface {
+	PerformLocketHealthCheck(ctx context.Context, logger lager.Logger, t time.Time) error
+}
+
+func (db *SQLDB) PerformLocketHealthCheck(ctx context.Context, logger lager.Logger, t time.Time) error {
+	logger = logger.Session("db")
+	logger.Debug("starting")
+	defer logger.Debug("done")
+
+	logger.Debug("upserting-time", lager.Data{"time": t})
+	_, err := db.helper.Upsert(
+		ctx,
+		logger,
+		db,
+		"locket_health_check",
+		helpers.SQLAttributes{"id": 1, "time": t.UnixNano()},
+		"id = ?",
+		1,
+	)
+	if err != nil {
+		return fmt.Errorf("failed upserting health check time: %s", err)
+	}
+
+	logger.Debug("retrieving-upserted-time")
+	scanner := db.QueryRowContext(ctx, helpers.RebindForFlavor("SELECT time from locket_health_check where id = ?", db.flavor), 1)
+	var insertedTime int64
+	err = scanner.Scan(&insertedTime)
+	if err != nil {
+		return fmt.Errorf("failed querying for health check time: %s", err)
+	}
+	logger.Debug("upserted-and-retrieved-time")
+	return nil
+}

--- a/db/locket_health_check_test.go
+++ b/db/locket_health_check_test.go
@@ -1,0 +1,51 @@
+package db_test
+
+import (
+	"time"
+
+	"code.cloudfoundry.org/bbs/db/sqldb/helpers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LocketHealthCheckDB", func() {
+	Context("when no previous healthcheck time exists", func() {
+		BeforeEach(func() {
+			rawDB.ExecContext(ctx, "DELETE FROM locket_health_check")
+		})
+		It("adds it", func() {
+			now := time.Now()
+			err := sqlDB.PerformLocketHealthCheck(ctx, logger, now)
+			Expect(err).NotTo(HaveOccurred())
+
+			scanner := rawDB.QueryRowContext(ctx, helpers.RebindForFlavor("SELECT * FROM locket_health_check WHERE id = ?", dbFlavor), 1)
+			var i int
+			var t int64
+			err = scanner.Scan(&i, &t)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(i).To(Equal(1))
+			Expect(t).To(Equal(now.UnixNano()))
+
+		})
+	})
+	Context("when a previous healthcheck time exists", func() {
+		BeforeEach(func() {
+			rawDB.ExecContext(ctx, "DELETE FROM locket_health_check")
+			_, err := rawDB.ExecContext(ctx, helpers.RebindForFlavor("INSERT INTO locket_health_check (id, time) VALUES(1, ?)", dbFlavor), time.Time{}.UnixNano())
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("updates it", func() {
+			now := time.Now()
+			err := sqlDB.PerformLocketHealthCheck(ctx, logger, now)
+			Expect(err).NotTo(HaveOccurred())
+
+			scanner := rawDB.QueryRowContext(ctx, helpers.RebindForFlavor("SELECT * FROM locket_health_check WHERE id = ?", dbFlavor), 1)
+			var i int
+			var t int64
+			err = scanner.Scan(&i, &t)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(i).To(Equal(1))
+			Expect(t).To(Equal(now.UnixNano()))
+		})
+	})
+})

--- a/db/queries.go
+++ b/db/queries.go
@@ -2,7 +2,9 @@ package db
 
 import (
 	"context"
+	"fmt"
 
+	"code.cloudfoundry.org/bbs/db/sqldb/helpers"
 	"code.cloudfoundry.org/lager/v3"
 )
 
@@ -20,6 +22,31 @@ func (db *SQLDB) CreateLockTable(ctx context.Context, logger lager.Logger) error
 	`)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (db *SQLDB) CreateHealthCheckTable(ctx context.Context, logger lager.Logger) error {
+	logger = logger.Session("create-health-check-table")
+	logger.Info("starting")
+	defer logger.Info("completed")
+
+	var createTableSQL string
+	switch db.flavor {
+	case helpers.MySQL:
+		createTableSQL = "CREATE TABLE IF NOT EXISTS locket_health_check (id int NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), time bigint NOT NULL)"
+	case helpers.Postgres:
+		createTableSQL = "CREATE TABLE IF NOT EXISTS locket_health_check (id SERIAL PRIMARY KEY, time bigint NOT NULL)"
+	default:
+		return fmt.Errorf("unsupported database flavor: %s", db.flavor)
+	}
+
+	logger.Info("creating-table")
+	_, err := db.ExecContext(ctx, helpers.RebindForFlavor(createTableSQL, db.flavor))
+	if err != nil {
+		logger.Error("failed-creating-table", err)
+		return fmt.Errorf("failed to create health check table: %w", err)
 	}
 
 	return nil

--- a/db/queries_test.go
+++ b/db/queries_test.go
@@ -1,0 +1,34 @@
+package db_test
+
+import (
+	"code.cloudfoundry.org/bbs/db/sqldb/helpers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CreateHealthCheckTable", func() {
+	It("creates the health check table successfully", func() {
+		err := sqlDB.CreateHealthCheckTable(ctx, logger)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify table exists by querying it
+		var count int
+		scanner := rawDB.QueryRowContext(ctx, helpers.RebindForFlavor("SELECT COUNT(*) FROM locket_health_check", dbFlavor))
+		err = scanner.Scan(&count)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("is idempotent and can be called multiple times", func() {
+		err := sqlDB.CreateHealthCheckTable(ctx, logger)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = sqlDB.CreateHealthCheckTable(ctx, logger)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify table still exists and is functional
+		var count int
+		scanner := rawDB.QueryRowContext(ctx, helpers.RebindForFlavor("SELECT COUNT(*) FROM locket_health_check", dbFlavor))
+		err = scanner.Scan(&count)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/schema.go
+++ b/schema.go
@@ -11,6 +11,9 @@ const MonitorRetryTime = 2 * time.Second
 const RetryInterval = 5 * time.Second
 const SQLRetryInterval = time.Second
 const ExpirationMetricsInterval = 60 * time.Second
+const DBHealthCheckTimeout = 5 * time.Second
+const DBHealthCheckInterval = 10 * time.Second
+const DBHealthCheckFailureThreshold = 3
 
 const LockSchemaRoot = "v1/locks"
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Implements a configurable database health check for Locket that monitors database connectivity and automatically restarts the process when failures are detected. Follows the same pattern as BBS (cloudfoundry/bbs#134).

  **Resolves**: cloudfoundry/diego-release#1105

  **Problem**: Locket can enter a degraded state when the database becomes unresponsive, with no automatic recovery mechanism.

  **Solution**:
  - Periodic health check (UPSERT + SELECT on dedicated table)
  - Configurable interval, timeout, and failure threshold
  - Automatic process exit on sustained failures, allowing BOSH to restart
  - **Disabled by default** for backward compatibility

  ### Test Results

  All tests passed on dev landscape with PostgreSQL backend:

  **Test 1 - Backward Compatibility (Health Check Disabled)**: ✅
  - Verified no health check activity when `enable_db_health_check: false` (default)
  - Locket functions normally without any behavior changes

  **Test 2 - Health Check Enabled and Working**: ✅
  - Health check runner started successfully
  - 54+ consecutive successful health checks observed
  - Checks occurring every 10 seconds as configured
  - Logs at INFO level: `locket.db-health-check-runner.health-check-succeeded`

  **Test 3 - Database Failure Detection**: ✅
  - Blocked database connectivity using iptables (PostgreSQL port 5432)
  - Health check detected failure in **12 seconds**
  - Three consecutive timeouts recorded (5s each)
  - Log message: `"database-failure-detected-restarting-locket"`
  - Locket process exited and was restarted by BOSH monit
  - Health checks resumed successfully after recovery

  **Test 4 - Timeout Protection**: ✅
  - Added 10 second network delay to database traffic
  - Health check timeout (5s) triggered correctly - didn't wait full 10s
  - Three consecutive timeouts detected
  - Locket restarted as expected
  - System recovered after removing delay
  - Confirms health checks don't hang on slow database

  **Test 5 - Configuration Parameters**: ✅
  - Verified all configuration values applied correctly:
    - `enable_db_health_check: true`
    - `health_check_interval: 10s`
    - `health_check_timeout: 5s`
    - `health_check_failure_threshold: 3`
  - Measured actual interval: exactly 10 seconds between checks

  ### Database Support
  - ✅ MySQL 8.0 (tested in docker)
  - ✅ PostgreSQL (tested in docker and on dev landscape)

Backward Compatibility
---------------
Breaking Change? **No**

This feature is **disabled by default** and requires explicit operator opt-in via the `enable_db_health_check` BOSH property. When disabled (default), Locket behaves exactly as before with no changes to functionality or performance.

  When enabled:
  - Locket creates an additional table `locket_health_check` (simple 2-column table)
  - Minimal performance overhead: one UPSERT + SELECT every 10 seconds
  - Only restarts on sustained database failures (3+ consecutive failures)
  - No breaking changes to existing APIs, interfaces, or behaviors
