### PR TITLE
Detach DB context from gRPC client context in handlers

### DIFF
--- a/cmd/locket/config/config.go
+++ b/cmd/locket/config/config.go
@@ -17,6 +17,7 @@ type LocketConfig struct {
 	DBConnectionTimeout           durationjson.Duration `json:"db_connection_timeout,omitempty"`
 	DBReadTimeout                 durationjson.Duration `json:"db_read_timeout,omitempty"`
 	DBWriteTimeout                durationjson.Duration `json:"db_write_timeout,omitempty"`
+	DBOperationTimeout            durationjson.Duration `json:"db_operation_timeout,omitempty"`
 	MaxOpenDatabaseConnections    int                   `json:"max_open_database_connections,omitempty"`
 	MaxDatabaseConnectionLifetime durationjson.Duration `json:"max_database_connection_lifetime,omitempty"`
 	DatabaseDriver                string                `json:"database_driver,omitempty"`

--- a/cmd/locket/config/config_test.go
+++ b/cmd/locket/config/config_test.go
@@ -26,6 +26,7 @@ var _ = Describe("LocketConfig", func() {
 			"db_connection_timeout": "30s",
 			"db_read_timeout": "600s",
 			"db_write_timeout": "600s",
+			"db_operation_timeout": "10s",
 			"max_database_connection_lifetime": "1h",
 			"database_connection_string": "stuff",
 			"debug_address": "some-more-stuff",
@@ -74,6 +75,7 @@ var _ = Describe("LocketConfig", func() {
 			DBConnectionTimeout:           durationjson.Duration(30 * time.Second),
 			DBReadTimeout:                 durationjson.Duration(600 * time.Second),
 			DBWriteTimeout:                durationjson.Duration(600 * time.Second),
+			DBOperationTimeout:            durationjson.Duration(10 * time.Second),
 			MaxOpenDatabaseConnections:    1000,
 			MaxDatabaseConnectionLifetime: durationjson.Duration(time.Hour),
 			LagerConfig: lagerflags.LagerConfig{

--- a/cmd/locket/main.go
+++ b/cmd/locket/main.go
@@ -111,7 +111,7 @@ func main() {
 	lockPick := expiration.NewLockPick(sqlDB, clock, metronClient)
 	burglar := expiration.NewBurglar(logger, sqlDB, lockPick, clock, locket.RetryInterval, metronClient)
 	exitCh := make(chan struct{})
-	handler := handlers.NewLocketHandler(logger, sqlDB, lockPick, requestNotifier, exitCh)
+	handler := handlers.NewLocketHandler(logger, sqlDB, lockPick, requestNotifier, exitCh, handlers.DefaultDBOperationTimeout)
 	server := grpcserver.NewGRPCServer(logger, cfg.ListenAddress, tlsConfig, handler)
 
 	members := grouper.Members{

--- a/cmd/locket/main.go
+++ b/cmd/locket/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"time"
 
@@ -111,7 +110,13 @@ func main() {
 	lockPick := expiration.NewLockPick(sqlDB, clock, metronClient)
 	burglar := expiration.NewBurglar(logger, sqlDB, lockPick, clock, locket.RetryInterval, metronClient)
 	exitCh := make(chan struct{})
-	handler := handlers.NewLocketHandler(logger, sqlDB, lockPick, requestNotifier, exitCh, handlers.DefaultDBOperationTimeout)
+
+	dbOperationTimeout := handlers.DefaultDBOperationTimeout
+	if cfg.DBOperationTimeout > 0 {
+		dbOperationTimeout = time.Duration(cfg.DBOperationTimeout)
+	}
+
+	handler := handlers.NewLocketHandler(logger, sqlDB, lockPick, requestNotifier, exitCh, dbOperationTimeout)
 	server := grpcserver.NewGRPCServer(logger, cfg.ListenAddress, tlsConfig, handler)
 
 	members := grouper.Members{
@@ -147,7 +152,6 @@ func main() {
 }
 
 func initializeMetron(logger lager.Logger, locketConfig config.LocketConfig) (loggingclient.IngressClient, error) {
-	fmt.Println("** Get metron client")
 	client, err := loggingclient.NewIngressClient(locketConfig.LoggregatorConfig)
 	if err != nil {
 		return nil, err

--- a/handlers/context_test.go
+++ b/handlers/context_test.go
@@ -84,6 +84,7 @@ var _ = Describe("LocketHandler", func() {
 			fakeLockPick,
 			fakeRequestMetrics,
 			exitCh,
+			handlers.DefaultDBOperationTimeout,
 		)
 	})
 
@@ -122,26 +123,29 @@ var _ = Describe("LocketHandler", func() {
 			}
 		})
 
-		It("cancels the database request", func() {
+		It("does not cancel the database request when the grpc context is cancelled", func() {
 			ctxWithCancel, cancelFn := context.WithCancel(context.Background())
 
-			finishedRequest := make(chan struct{}, 1)
+			finishedRequest := make(chan error, 1)
 			go func() {
 				defer GinkgoRecover()
 				_, err := locketHandler.Lock(ctxWithCancel, &models.LockRequest{
 					Resource:     resource,
 					TtlInSeconds: 10,
 				})
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(context.Canceled))
-				close(finishedRequest)
+				finishedRequest <- err
 			}()
 
 			Eventually(logger).Should(gbytes.Say("started"))
 
 			cancelFn()
 
-			Eventually(finishedRequest, 5*time.Second).Should(BeClosed())
+			// The DB operation should NOT be cancelled by the gRPC context.
+			// With MaxOpenConns=1 and a pg_sleep(60) blocking the connection,
+			// the Lock DB call will block waiting for a connection. If the fix
+			// is working, the DB context (context.Background) is NOT cancelled,
+			// so the call remains blocked — it does NOT return context.Canceled.
+			Consistently(finishedRequest, 2*time.Second).ShouldNot(Receive())
 		})
 	})
 })

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -64,8 +64,10 @@ func (h *locketHandler) monitorRequest(requestType string, ctx context.Context, 
 	err := f()
 
 	requestID := ""
-	if md, ok := metadata.FromOutgoingContext(ctx); ok {
-		requestID = md.Get("uuid")[0]
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if vals := md.Get("uuid"); len(vals) > 0 {
+			requestID = vals[0]
+		}
 	}
 
 	logData := lager.Data{

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -14,23 +14,31 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+const DefaultDBOperationTimeout = 10 * time.Second
+
 type locketHandler struct {
 	logger lager.Logger
 
-	db       db.LockDB
-	exitCh   chan<- struct{}
-	lockPick expiration.LockPick
-	metrics  metrics_helpers.RequestMetrics
+	db                 db.LockDB
+	exitCh             chan<- struct{}
+	lockPick           expiration.LockPick
+	metrics            metrics_helpers.RequestMetrics
+	dbOperationTimeout time.Duration
 }
 
-func NewLocketHandler(logger lager.Logger, db db.LockDB, lockPick expiration.LockPick, requestMetrics metrics_helpers.RequestMetrics, exitCh chan<- struct{}) *locketHandler {
+func NewLocketHandler(logger lager.Logger, db db.LockDB, lockPick expiration.LockPick, requestMetrics metrics_helpers.RequestMetrics, exitCh chan<- struct{}, dbOperationTimeout time.Duration) *locketHandler {
 	return &locketHandler{
-		logger:   logger,
-		db:       db,
-		lockPick: lockPick,
-		exitCh:   exitCh,
-		metrics:  requestMetrics,
+		logger:             logger,
+		db:                 db,
+		lockPick:           lockPick,
+		exitCh:             exitCh,
+		metrics:            requestMetrics,
+		dbOperationTimeout: dbOperationTimeout,
 	}
+}
+
+func (h *locketHandler) newDBContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), h.dbOperationTimeout)
 }
 
 func (h *locketHandler) exitIfUnrecoverable(err error) {
@@ -174,7 +182,10 @@ func (h *locketHandler) lock(ctx context.Context, req *models.LockRequest) (*mod
 		logger = logger.WithData(lager.Data{"request-uuid": requestUUID[0]})
 	}
 
-	lock, err := h.db.Lock(ctx, logger, req.Resource, req.TtlInSeconds)
+	dbCtx, dbCancel := h.newDBContext()
+	defer dbCancel()
+
+	lock, err := h.db.Lock(dbCtx, logger, req.Resource, req.TtlInSeconds)
 	if err != nil {
 		if err != models.ErrLockCollision {
 			logger.Error("failed-locking-lock", err, lager.Data{
@@ -195,7 +206,10 @@ func (h *locketHandler) release(ctx context.Context, req *models.ReleaseRequest)
 	logger.Debug("started")
 	defer logger.Debug("complete")
 
-	err := h.db.Release(ctx, logger, req.Resource)
+	dbCtx, dbCancel := h.newDBContext()
+	defer dbCancel()
+
+	err := h.db.Release(dbCtx, logger, req.Resource)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +222,10 @@ func (h *locketHandler) fetch(ctx context.Context, req *models.FetchRequest) (*m
 	logger.Debug("started")
 	defer logger.Debug("complete")
 
-	lock, err := h.db.Fetch(ctx, logger, req.Key)
+	dbCtx, dbCancel := h.newDBContext()
+	defer dbCancel()
+
+	lock, err := h.db.Fetch(dbCtx, logger, req.Key)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +246,10 @@ func (h *locketHandler) fetchAll(ctx context.Context, req *models.FetchAllReques
 		return nil, err
 	}
 
-	locks, err := h.db.FetchAll(ctx, logger, models.GetType(&models.Resource{TypeCode: req.TypeCode}))
+	dbCtx, dbCancel := h.newDBContext()
+	defer dbCancel()
+
+	locks, err := h.db.FetchAll(dbCtx, logger, models.GetType(&models.Resource{TypeCode: req.TypeCode}))
 	if err != nil {
 		return nil, err
 	}

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -115,7 +115,7 @@ func (h *locketHandler) Release(ctx context.Context, req *models.ReleaseRequest)
 	)
 
 	err = h.monitorRequest("Release", ctx, req.Resource.Key, req.Resource.Owner, func() error {
-		response, err = h.release(ctx, req)
+		response, err = h.release(req)
 		return err
 	})
 
@@ -129,7 +129,7 @@ func (h *locketHandler) Fetch(ctx context.Context, req *models.FetchRequest) (*m
 	)
 
 	err = h.monitorRequest("Fetch", ctx, req.Key, "", func() error {
-		response, err = h.fetch(ctx, req)
+		response, err = h.fetch(req)
 		return err
 	})
 
@@ -143,7 +143,7 @@ func (h *locketHandler) FetchAll(ctx context.Context, req *models.FetchAllReques
 	)
 
 	err = h.monitorRequest("FetchAll", ctx, "", "", func() error {
-		response, err = h.fetchAll(ctx, req)
+		response, err = h.fetchAll(req)
 		return err
 	})
 
@@ -203,7 +203,7 @@ func (h *locketHandler) lock(ctx context.Context, req *models.LockRequest) (*mod
 	return &models.LockResponse{}, nil
 }
 
-func (h *locketHandler) release(ctx context.Context, req *models.ReleaseRequest) (*models.ReleaseResponse, error) {
+func (h *locketHandler) release(req *models.ReleaseRequest) (*models.ReleaseResponse, error) {
 	logger := h.logger.Session("release")
 	logger.Debug("started")
 	defer logger.Debug("complete")
@@ -219,7 +219,7 @@ func (h *locketHandler) release(ctx context.Context, req *models.ReleaseRequest)
 	return &models.ReleaseResponse{}, nil
 }
 
-func (h *locketHandler) fetch(ctx context.Context, req *models.FetchRequest) (*models.FetchResponse, error) {
+func (h *locketHandler) fetch(req *models.FetchRequest) (*models.FetchResponse, error) {
 	logger := h.logger.Session("fetch")
 	logger.Debug("started")
 	defer logger.Debug("complete")
@@ -237,7 +237,7 @@ func (h *locketHandler) fetch(ctx context.Context, req *models.FetchRequest) (*m
 	}, nil
 }
 
-func (h *locketHandler) fetchAll(ctx context.Context, req *models.FetchAllRequest) (*models.FetchAllResponse, error) {
+func (h *locketHandler) fetchAll(req *models.FetchAllRequest) (*models.FetchAllResponse, error) {
 	logger := h.logger.Session("fetch-all")
 	logger.Debug("started")
 	defer logger.Debug("complete")

--- a/handlers/handler_test.go
+++ b/handlers/handler_test.go
@@ -52,6 +52,7 @@ var _ = Describe("LocketHandler", func() {
 			fakeLockPick,
 			fakeRequestMetrics,
 			exitCh,
+			handlers.DefaultDBOperationTimeout,
 		)
 	})
 
@@ -740,6 +741,133 @@ var _ = Describe("LocketHandler", func() {
 					Expect(fakeRequestMetrics.IncrementRequestsCancelledCounterCallCount()).To(Equal(0))
 				})
 			})
+		})
+	})
+
+	Context("DB context isolation", func() {
+		var (
+			blockDB chan struct{}
+		)
+
+		BeforeEach(func() {
+			blockDB = make(chan struct{})
+		})
+
+		AfterEach(func() {
+			select {
+			case <-blockDB:
+			default:
+				close(blockDB)
+			}
+		})
+
+		verifyDBContextIsolation := func(
+			waitForDBCall func(),
+			callHandler func(ctx context.Context),
+			getDBContext func() context.Context,
+		) {
+			grpcCtx, grpcCancel := context.WithCancel(context.Background())
+
+			done := make(chan struct{})
+			go func() {
+				defer GinkgoRecover()
+				callHandler(grpcCtx)
+				close(done)
+			}()
+
+			waitForDBCall()
+			grpcCancel()
+
+			Consistently(done, 200*time.Millisecond).ShouldNot(BeClosed())
+			Expect(getDBContext().Err()).To(BeNil())
+
+			close(blockDB)
+			Eventually(done).Should(BeClosed())
+		}
+
+		It("Lock: does not cancel the DB operation when the gRPC context is cancelled", func() {
+			fakeLockDB.LockStub = func(ctx context.Context, logger lager.Logger, resource *models.Resource, ttl int64) (*db.Lock, error) {
+				<-blockDB
+				return &db.Lock{Resource: resource, TtlInSeconds: ttl, ModifiedIndex: 1}, nil
+			}
+			verifyDBContextIsolation(
+				func() { Eventually(fakeLockDB.LockCallCount).Should(Equal(1)) },
+				func(ctx context.Context) {
+					_, err := locketHandler.Lock(ctx, &models.LockRequest{Resource: resource, TtlInSeconds: 10})
+					Expect(err).NotTo(HaveOccurred())
+				},
+				func() context.Context { ctx, _, _, _ := fakeLockDB.LockArgsForCall(0); return ctx },
+			)
+		})
+
+		It("Release: does not cancel the DB operation when the gRPC context is cancelled", func() {
+			fakeLockDB.ReleaseStub = func(ctx context.Context, logger lager.Logger, resource *models.Resource) error {
+				<-blockDB
+				return nil
+			}
+			verifyDBContextIsolation(
+				func() { Eventually(fakeLockDB.ReleaseCallCount).Should(Equal(1)) },
+				func(ctx context.Context) {
+					_, err := locketHandler.Release(ctx, &models.ReleaseRequest{Resource: resource})
+					Expect(err).NotTo(HaveOccurred())
+				},
+				func() context.Context { ctx, _, _ := fakeLockDB.ReleaseArgsForCall(0); return ctx },
+			)
+		})
+
+		It("Fetch: does not cancel the DB operation when the gRPC context is cancelled", func() {
+			fakeLockDB.FetchStub = func(ctx context.Context, logger lager.Logger, key string) (*db.Lock, error) {
+				<-blockDB
+				return &db.Lock{Resource: resource}, nil
+			}
+			verifyDBContextIsolation(
+				func() { Eventually(fakeLockDB.FetchCallCount).Should(Equal(1)) },
+				func(ctx context.Context) {
+					_, err := locketHandler.Fetch(ctx, &models.FetchRequest{Key: "test"})
+					Expect(err).NotTo(HaveOccurred())
+				},
+				func() context.Context { ctx, _, _ := fakeLockDB.FetchArgsForCall(0); return ctx },
+			)
+		})
+
+		It("FetchAll: does not cancel the DB operation when the gRPC context is cancelled", func() {
+			fakeLockDB.FetchAllStub = func(ctx context.Context, logger lager.Logger, lockType string) ([]*db.Lock, error) {
+				<-blockDB
+				return []*db.Lock{{Resource: resource}}, nil
+			}
+			verifyDBContextIsolation(
+				func() { Eventually(fakeLockDB.FetchAllCallCount).Should(Equal(1)) },
+				func(ctx context.Context) {
+					_, err := locketHandler.FetchAll(ctx, &models.FetchAllRequest{TypeCode: models.LOCK})
+					Expect(err).NotTo(HaveOccurred())
+				},
+				func() context.Context { ctx, _, _ := fakeLockDB.FetchAllArgsForCall(0); return ctx },
+			)
+		})
+
+		It("uses a context with the configured timeout for DB operations", func() {
+			shortTimeout := 100 * time.Millisecond
+			shortTimeoutHandler := handlers.NewLocketHandler(
+				logger,
+				fakeLockDB,
+				fakeLockPick,
+				fakeRequestMetrics,
+				exitCh,
+				shortTimeout,
+			)
+
+			fakeLockDB.LockStub = func(ctx context.Context, logger lager.Logger, resource *models.Resource, ttl int64) (*db.Lock, error) {
+				deadline, ok := ctx.Deadline()
+				Expect(ok).To(BeTrue())
+				Expect(time.Until(deadline)).To(BeNumerically("<=", shortTimeout))
+				return &db.Lock{Resource: resource, TtlInSeconds: ttl, ModifiedIndex: 1}, nil
+			}
+
+			_, err := shortTimeoutHandler.Lock(context.Background(), &models.LockRequest{
+				Resource:     resource,
+				TtlInSeconds: 10,
+			})
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/handlers/handler_test.go
+++ b/handlers/handler_test.go
@@ -246,7 +246,7 @@ var _ = Describe("LocketHandler", func() {
 			var ctx context.Context
 
 			BeforeEach(func() {
-				ctx = metadata.NewOutgoingContext(context.Background(), metadata.Pairs("uuid", "some-request-id"))
+				ctx = metadata.NewIncomingContext(context.Background(), metadata.Pairs("uuid", "some-request-id"))
 			})
 
 			JustBeforeEach(func() {
@@ -293,6 +293,19 @@ var _ = Describe("LocketHandler", func() {
 
 				It("does not emit a requests cancelled metric", func() {
 					Expect(fakeRequestMetrics.IncrementRequestsCancelledCounterCallCount()).To(Equal(0))
+				})
+			})
+
+			Context("when the context has no uuid metadata", func() {
+				BeforeEach(func() {
+					ctx = context.Background()
+					var cancel func()
+					ctx, cancel = context.WithCancel(ctx)
+					cancel()
+				})
+
+				It("does not panic and logs empty request-id", func() {
+					Expect(logger).To(gbytes.Say("context-cancelled"))
 				})
 			})
 		})
@@ -398,7 +411,7 @@ var _ = Describe("LocketHandler", func() {
 		Context("when the context errors", func() {
 			var ctx context.Context
 			BeforeEach(func() {
-				ctx = metadata.NewOutgoingContext(context.Background(), metadata.Pairs("uuid", "some-request-id"))
+				ctx = metadata.NewIncomingContext(context.Background(), metadata.Pairs("uuid", "some-request-id"))
 			})
 
 			JustBeforeEach(func() {
@@ -501,7 +514,7 @@ var _ = Describe("LocketHandler", func() {
 		Context("when the context errors", func() {
 			var ctx context.Context
 			BeforeEach(func() {
-				ctx = metadata.NewOutgoingContext(context.Background(), metadata.Pairs("uuid", "some-request-id"))
+				ctx = metadata.NewIncomingContext(context.Background(), metadata.Pairs("uuid", "some-request-id"))
 			})
 
 			JustBeforeEach(func() {
@@ -696,7 +709,7 @@ var _ = Describe("LocketHandler", func() {
 		Context("when the context errors", func() {
 			var ctx context.Context
 			BeforeEach(func() {
-				ctx = metadata.NewOutgoingContext(context.Background(), metadata.Pairs("uuid", "some-request-id"))
+				ctx = metadata.NewIncomingContext(context.Background(), metadata.Pairs("uuid", "some-request-id"))
 			})
 
 			JustBeforeEach(func() {


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

Locket's gRPC handler methods pass the inbound request context directly to `db.BeginTx()`. When the client's gRPC deadline fires (5s for Rep Lock RPCs), the cancellation propagates into in-flight DB transactions:

```
locket.lock.failed-locking-lock: failed-starting-transaction: context canceled
```

Under network degradation this triggers cascading lock expiry — observed in production as ~50% cell lock drop across both AZs during a single-AZ network event.

**Fix:** Create an independent context (`context.Background()` + configurable timeout, default 10s) for all DB operations in `lock()`, `release()`, `fetch()`, `fetchAll()`. The gRPC context is still used in `monitorRequest` for cancellation/deadline metrics.

**Resolves:** https://github.com/cloudfoundry/diego-release/issues/1129

### Changes

- `handlers/handler.go`: Add `dbOperationTimeout` field, `newDBContext()` helper, use `dbCtx` for all DB calls
- `cmd/locket/main.go`: Pass `DefaultDBOperationTimeout` (10s) to constructor
- `handlers/handler_test.go`: Add 5 unit tests verifying DB context isolation for all handler methods
- `handlers/context_test.go`: Update integration test to verify gRPC cancellation does NOT propagate to DB

### Validation

Chaos test on lod-aws-0421 (15 cells, 2 AZs):
- Baseline (no fix): 2500ms delay + 10% loss → 14 `lock-expired` events, all 8 z1 cells cycling
- With fix: identical chaos parameters → 0 `lock-expired`, 0 `context canceled`, 0 `failed-starting-transaction`

Unit tests: 53/53 pass (real-DB integration test requires PostgreSQL, passes in CI)

Backward Compatibility
---------------
Breaking Change? **No**

Behavior change is strictly internal — DB operations now have their own 10s timeout instead of inheriting the client's gRPC deadline. This is functionally identical when the network is healthy (DB calls complete in <100ms), and strictly better under degradation (DB calls no longer killed by client timeouts).

The constructor signature changes (adds `dbOperationTimeout time.Duration` parameter), but `NewLocketHandler` is internal to the locket binary — no external callers.