### PR TITLE
fix(test): update loggregator-down test for non-blocking dial and fix missing locket_health_check table setup

### DIFF
--- a/cmd/locket/main_test.go
+++ b/cmd/locket/main_test.go
@@ -81,9 +81,12 @@ var _ = Describe("Locket", func() {
 				})
 			})
 
-			It("exit with non-zero status code", func() {
+			// diego-logging-client now dials loggregator non-blocking (lazy). Locket
+			// starts successfully and retries the connection in the background, so
+			// it must NOT exit when the loggregator agent is temporarily unavailable.
+			It("starts successfully and does not exit", func() {
 				locketProcess = ifrit.Invoke(locketRunner)
-				Eventually(locketProcess.Wait()).Should(Receive(HaveOccurred()))
+				Consistently(locketProcess.Wait()).ShouldNot(Receive())
 			})
 		})
 

--- a/db/sqldb_suite_test.go
+++ b/db/sqldb_suite_test.go
@@ -98,6 +98,8 @@ var _ = BeforeSuite(func() {
 	sqlDB = sqldb.NewSQLDB(db, dbFlavor, fakeGUIDProvider)
 	err = sqlDB.CreateLockTable(ctx, logger)
 	Expect(err).NotTo(HaveOccurred())
+	err = sqlDB.CreateHealthCheckTable(ctx, logger)
+	Expect(err).NotTo(HaveOccurred())
 
 	sqlHelper = helpers.NewSQLHelper(dbFlavor)
 
@@ -138,4 +140,5 @@ func truncateTables(db *sql.DB) {
 
 var truncateTablesSQL = []string{
 	"TRUNCATE TABLE locks",
+	"TRUNCATE TABLE locket_health_check",
 }


### PR DESCRIPTION
## Summary

Fixes two test failures in the locket test suite introduced by upstream changes.

**Failure 1 — cmd/locket/main_test.go:86**
"when the loggregator configuration isn't valid or the agent isn't up → exit with non-zero status code"

PR [cloudfoundry/diego-logging-client#<N>](https://github.com/cloudfoundry/diego-logging-client/pull/131) (tnz-96145) changed `NewIngressClient` to use a non-blocking gRPC dial. Previously, if the loggregator agent was unavailable, NewIngressClient returned an error and locket exited. With the lazy dial the call always succeeds and
locket starts normally, retrying the connection in the background.

The test assertion:
`  Eventually(locketProcess.Wait()).Should(Receive(HaveOccurred()))`

now times out because locket no longer exits. Changed to:
`  Consistently(locketProcess.Wait()).ShouldNot(Receive())`

**Failure 2 — db/locket_health_check_test.go:35**
ERROR: relation "locket_health_check" does not exist (SQLSTATE 42P01)

PR dab2474 ("Add configurable DB health check to Locket") introduced LocketHealthCheckDB and locket_health_check_test.go, but did not update db/sqldb_suite_test.go to call CreateHealthCheckTable in BeforeSuite. The locket_health_check table is therefore never created and every BeforeEach in locket_health_check_test.go that inserts or queries from it fails immediately.

Fix: call CreateHealthCheckTable in BeforeSuite (after CreateLockTable) and add TRUNCATE TABLE locket_health_check to the truncateTablesSQL slice so tests are isolated between runs.

**Prior work**
- Non-blocking loggregator dial: cloudfoundry/diego-logging-client#<N> (tnz-96145)
- DB health check feature: dab2474
- FakeLocketHealthCheckDB (already merged): 54bfe43

## Backward Compatibility
Breaking Change? **No**

Test-only changes. No production code, interfaces, or behaviour are modified.